### PR TITLE
fix: remove square brackets

### DIFF
--- a/src/copy_link_cosense.js
+++ b/src/copy_link_cosense.js
@@ -1,5 +1,6 @@
 (() => {
-	const textToCopy = `[${document.title} ${window.location.href}]`;
+	const title = document.title.replace("[", "").replace("]", "");
+	const textToCopy = `[${title} ${window.location.href}]`;
 	navigator.clipboard.writeText(textToCopy).then(
 		(data) => {
 			const message = document.createElement("div");


### PR DESCRIPTION
- 取得したページタイトルから、 `[` と `]` を削除する